### PR TITLE
Fix last level printing when using python module

### DIFF
--- a/src/community.cpp
+++ b/src/community.cpp
@@ -287,7 +287,7 @@ void Community::print_level(int level) {
     for (unsigned int i = 0; i < this->g->nodes; i++)
         n2c[i] = i;
 
-    for (int l = 0; l < level-1; l++)
+    for (int l = 0; l < level; l++)
         for (unsigned int node = 0; node < this->g->nodes; node++)
             n2c[node] = this->levels[l][n2c[node]];
 


### PR DESCRIPTION
After compiling and using the python module, the `dl_obj.print_level()` function (taken from the [HelloWorld](https://github.com/nicolasdugue/DirectedLouvain/blob/master/python-binding/notebook/HelloWorld.ipynb) Notebook) does not print the correct level. It actually prints one level behind of the input level,  i.e. if there are total 4 levels,  `dl_obj.print_level(3)` should print the last level (4th level), instead it prints the (3rd Level).

This is caused be as the loop on [line 290 of community.cpp](https://github.com/nicolasdugue/DirectedLouvain/blob/c05ff669265d9e259afef02df235f79772cc12bc/src/community.cpp#L290) iterates only till `level-1`.

Due to this it also becomes impossible to print the last level by using workaround `level+1`  input to `dl_obj.print_level()` as [this assertion](https://github.com/nicolasdugue/DirectedLouvain/blob/c05ff669265d9e259afef02df235f79772cc12bc/src/community.cpp#L284) prevents it from happening.

This PR fixes that issue.


> Note:  This issues does not occur when directly using the compiled binaries from cpp, as it uses hierarchy.cpp which uses its [own loop](https://github.com/nicolasdugue/DirectedLouvain/blob/c05ff669265d9e259afef02df235f79772cc12bc/src/hierarchy.cpp#L139) and displays the correct level.